### PR TITLE
lx2160a_uefi: runme.sh fix flexspi_nor/sd targets

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -180,9 +180,9 @@ fi
 truncate -s 8M $ROOTDIR/images/${IMG}
 
 # RCW+PBI+BL2 at block 8
-if [ "x$BOOT_MODE" == "flexspi_nor" ]; then
+if [ "x$BOOT_MODE" == "xflexspi_nor" ]; then
 dd if=$ROOTDIR/build/arm-trusted-firmware/build/lx2160acex7/release/bl2_flexspi_nor.pbl of=images/${IMG} bs=512 conv=notrunc
-elif [ "x$BOOT_MODE" == "sd" ]; then
+elif [ "x$BOOT_MODE" == "xsd" ]; then
 dd if=$ROOTDIR/build/arm-trusted-firmware/build/lx2160acex7/release/bl2_sd.pbl of=images/${IMG} bs=512 seek=8 conv=sparse
 else
 dd if=$ROOTDIR/build/arm-trusted-firmware/build/lx2160acex7/release/bl2_auto.pbl of=images/${IMG} bs=512 conv=notrunc


### PR DESCRIPTION
The test(1) check is if "x${..}" == ".." instead of == "x..".
This should make the image creation for flexspi_nor and sd do
the right thing.