### PR TITLE
Support building for BOOT_MODE == "emmc"

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -225,6 +225,8 @@ if [ "x$BOOT_MODE" == "xflexspi_nor" ]; then
 dd if=$ROOTDIR/build/arm-trusted-firmware/build/lx2160acex7/release/bl2_flexspi_nor.pbl of=images/${IMG} bs=512 conv=notrunc
 elif [ "x$BOOT_MODE" == "xsd" ]; then
 dd if=$ROOTDIR/build/arm-trusted-firmware/build/lx2160acex7/release/bl2_sd.pbl of=images/${IMG} bs=512 seek=8 conv=sparse
+elif [ "x$BOOT_MODE" == "xemmc" ]; then
+dd if=$ROOTDIR/build/arm-trusted-firmware/build/lx2160acex7/release/bl2_emmc.pbl of=images/${IMG} bs=512 seek=8 conv=sparse
 fi
 
 # DDR PHY FIP at 0x100


### PR DESCRIPTION
Build-tested and run-tested on LX2160A COM rev 1.3 and early ClearFog CX LX2 carrier board.

Flashed from microSD u-boot with:

```
usb start
load usb 0:1 0xa4000000 lx2160acex7_2200_800_3200_8_5_2_emmc_ee5c233.img
mmc dev 1
mmc write 0xa4000000 0 0xd2000
```