### PR TITLE
Update Dockerfile to fix dubious ownership error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update ; apt-get -y --no-install-recommends install \
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
 
+RUN git config --global --add safe.directory '*'
+
 # build environment
 ARG ddr=2400
 ENV DDR_SPEED=$ddr


### PR DESCRIPTION
`docker run` now throws an error 'fatal: detected dubious ownership in repository at '/work'' when updating submodules.

Fix this by having git consider all directories as safe in the image.