### PR TITLE
Refreshment after 4 years of no activity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,8 +16,8 @@
 	branch = 3.14.0-cex7
 [submodule "build/tianocore/edk2"]
 	path = build/tianocore/edk2
-	url = https://github.com/SolidRun/edk2.git
-	branch = edk2-stable202105-lx2160acex7
+	url = https://github.com/tianocore/edk2.git
+	branch = edk2-stable202508
 [submodule "build/tianocore/edk2-platforms"]
 	path = build/tianocore/edk2-platforms
 	url = https://github.com/SolidRun/edk2-platforms.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,17 @@
 # use debian base
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # update
 RUN set -e; \
-	apt-get update; \
-	apt-get -y upgrade; \
-	:
+        apt-get update; \
+        apt-get -y upgrade; \
+        :
 
 RUN apt-get update ; apt-get -y --no-install-recommends install \
-	wget make acpica-tools device-tree-compiler xz-utils \
-	sudo git gettext-base uuid-dev bc gcc g++ python3 \ 
-	libc6-dev libssl-dev python3-distutils ca-certificates
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+        wget make acpica-tools device-tree-compiler xz-utils \
+        sudo git gettext-base uuid-dev bc gcc g++ python3 \
+        python3-pycryptodome python-is-python3 python3-pyelftools \
+        libc6-dev libssl-dev python3-distutils ca-certificates
 
 # build environment
 ARG ddr=2400


### PR DESCRIPTION
This PR switches build image to Debian Bullseye. And to upstream EDK2.

Build tested on LX2160. And just flashed to SD card and it boots. No issues observed.

You may want to consider merging if desired.